### PR TITLE
Make browser pop up

### DIFF
--- a/src/alerts.py
+++ b/src/alerts.py
@@ -50,7 +50,7 @@ def alert(msg: str, verbose: bool = False) -> None:
     if settings.OPEN_BROWSER:
         verbose_info(f"[WEBBROWSER] try to open browser")
         try:
-            webbrowser.open(appointment_url)
+            webbrowser.open(appointment_url, new=1, autoraise=True)
             verbose_info(f"[WEBBROWSER] open browser was successful")
         except Exception as e:
             log.error(f"Couldn't open browser: {e}")


### PR DESCRIPTION
Hi and thanks for this nice weekend project :smile: 

Perhaps my problem is a bit exotic, but I think the suggested change does not hurt in any case.

On i3 window manager (and perhaps other desktop environments?) one has to create a new browser window to make the browser pop up if a place becomes available. Otherwise, the page might open in the background, unnoticed.

This PR fixes the problem by requesting a new browser window when an alert is triggered.